### PR TITLE
fix: prevent reordering from clearing edited text

### DIFF
--- a/scripts/events.lua
+++ b/scripts/events.lua
@@ -562,6 +562,7 @@ return {
 
                         update_subtask_flow(force, parenttask.subtasks, task.parent_string)
                     else
+                        check_texts(force, playermeta)
                         local lookup = script_data.unfinished_todo[force]
                         local change = "unfinished_index"
 
@@ -609,6 +610,7 @@ return {
 
                         update_subtask_flow(force, parenttask.subtasks, task.parent_string)
                     else
+                        check_texts(force, playermeta)
                         local lookup = script_data.unfinished_todo[force]
                         local change = "unfinished_index"
 

--- a/scripts/events.lua
+++ b/scripts/events.lua
@@ -70,7 +70,9 @@ local function update_checkboxes(force, state, namestring)
     end
 end
 
-local function check_texts(force, playermeta)
+-- Don't clear the edit title/descriptions if we want to keep editing after this check
+local function check_texts(force, playermeta, keep_editing)
+    keep_editing = keep_editing or false
     local todo = script_data.todo[force]
     local player_lookup = script_data.player_lookup[force]
     local enddata = {}
@@ -79,8 +81,10 @@ local function check_texts(force, playermeta)
     for namestring, title in pairs(playermeta.titles) do
         local description = playermeta.descriptions[namestring]
 
-        playermeta.edit_titles[namestring] = nil
-        playermeta.edit_descriptions[namestring] = nil
+        if not keep_editing then
+            playermeta.edit_titles[namestring] = nil
+            playermeta.edit_descriptions[namestring] = nil
+        end
 
         if title.style.font == "default-bold" or description.style.font == "default-bold" then
             local data = todo[namestring]
@@ -562,7 +566,6 @@ return {
 
                         update_subtask_flow(force, parenttask.subtasks, task.parent_string)
                     else
-                        check_texts(force, playermeta)
                         local lookup = script_data.unfinished_todo[force]
                         local change = "unfinished_index"
 
@@ -574,6 +577,7 @@ return {
                             change = "all_index"
                         end
 
+                        check_texts(force, playermeta, true)
                         table.remove(lookup, task[change])
 
                         if button == definesbutton.left then
@@ -610,7 +614,6 @@ return {
 
                         update_subtask_flow(force, parenttask.subtasks, task.parent_string)
                     else
-                        check_texts(force, playermeta)
                         local lookup = script_data.unfinished_todo[force]
                         local change = "unfinished_index"
 
@@ -622,6 +625,7 @@ return {
                             change = "all_index"
                         end
 
+                        check_texts(force, playermeta, true)
                         table.remove(lookup, task[change])
 
                         if button == definesbutton.left then

--- a/scripts/player.lua
+++ b/scripts/player.lua
@@ -121,8 +121,8 @@ function player_data:build_scrollpane(script_data)
     self.descriptions = {}
     self.players = {}
     self.toggles = {}
-    self.edit_titles = {}
-    self.edit_descriptions = {}
+    self.edit_titles = self.edit_titles or {}
+    self.edit_descriptions = self.edit_descriptions or {}
 
     for i, namestring in pairs(lookup) do
         self:add_task(script_data.todo[force], script_data.player_table[force], namestring, task_amount, i)


### PR DESCRIPTION
Adds calls to `check_texts` to the reorder event handlers to make sure to capture any changes in text before reordering the data. Also makes sure that we don't lose existing edited titles or description on building the scroll pane, so that we preserve the existing formatting for edited items.

Fixes #4