### PR TITLE
feat: overhauls all_todo by computing it dynamically

### DIFF
--- a/scripts/player.lua
+++ b/scripts/player.lua
@@ -1,4 +1,5 @@
 local mod_gui = require "mod-gui"
+local utils = require "scripts/utils"
 local player_data = {}
 local filter = {"left"}
 
@@ -110,7 +111,7 @@ function player_data:build_scrollpane(script_data)
     local switch_state = self.switch_state
     local table = self.table
     local force = self.force
-    local lookup = (switch_state == "left" and script_data.finished_todo[force]) or (switch_state == "none" and script_data.all_todo[force]) or script_data.unfinished_todo[force]
+    local lookup = (switch_state == "left" and script_data.finished_todo[force]) or (switch_state == "none" and all_todo(script_data, force)) or script_data.unfinished_todo[force]
     local task_amount = #lookup
 
     table.clear()

--- a/scripts/utils.lua
+++ b/scripts/utils.lua
@@ -1,0 +1,13 @@
+-- Merges two tables indexed by numbers together into one longer table (original tables are untouched)
+local function merge(a, b)
+    local result = { unpack(a) }
+    for i = 1, #b do
+        result[#a+i] = b[i]
+    end
+    return result
+end
+
+-- Combines unfinished and finished todos into one combined list based on current script data and a force
+function all_todo(script_data, force)
+    return merge(script_data.unfinished_todo[force], script_data.finished_todo[force])
+end


### PR DESCRIPTION
Makes all ordering issues between the all tab and non-all tabs go away by creating the `all_todo` table whenever it's needed. Instead of a separate source of truth, having just one place to pull data from for todos means order can be consistent always and there aren't bugs with different data sets.

The migration from 0.2 is the only part that I'm not sure I did right given that I didn't test that in depth.

Fixes #11 and other classes of bugs like it entirely.