### PR TITLE
fix: close all GUIs when switching forces, not just main window

### DIFF
--- a/scripts/events.lua
+++ b/scripts/events.lua
@@ -972,7 +972,8 @@ return {
             script_data.player_table[newid][player_id] = player.name
             script_data.player_lookup[newid][player.name] = player_id
 
-            if playermeta.frame then
+            -- If any windows are open (main one or specific tasks), clear both them and their references
+            if playermeta.frame or not (next(playermeta.reference_frames) == nil) then
                 playermeta:clear()
 
                 for id_string, _ in pairs(playermeta.reference_frames) do

--- a/scripts/player.lua
+++ b/scripts/player.lua
@@ -498,7 +498,7 @@ function player_data:reference_subtasks(subtasks, todo, flow)
 end
 
 function player_data:clear()
-    self.frame.destroy()
+    if self.frame then self.frame.destroy() end
     self.frame = nil
     self.edit_button = nil
     self.import_button = nil


### PR DESCRIPTION
If the main window wasn't open when switching forces, the individual todo windows could be left open and cause a crash when a todo was completed in a different surface than the one it was created in. This mitigates that by closing all windows when switching forces, not just the main one.

Fixes #9 